### PR TITLE
Framework updates (.net 8.0 & Avalonia 11.2.7) and related code updates.

### DIFF
--- a/AnimationOnTabControlChange/AnimateTabControl.cs
+++ b/AnimationOnTabControlChange/AnimateTabControl.cs
@@ -1,42 +1,37 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
-using Avalonia.Styling;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AnimationOnTabControlChange
 {
-    [PseudoClasses(":normal")]
-    public class AnimateTabControl : TabControl, IStyleable
-    {
-        Type IStyleable.StyleKey => typeof(TabControl);
+	[PseudoClasses(":normal")]
+	public class AnimateTabControl : TabControl
+	{
+		protected override Type StyleKeyOverride => typeof(TabControl);
 
-        public AnimateTabControl()
-        {
-            PseudoClasses.Add(":normal");
-            this.GetObservable(SelectedContentProperty).Subscribe(OnContentChanged);
-        }
+		public AnimateTabControl()
+		{
+			PseudoClasses.Add(":normal");
+			SelectionChanged += OnContentChanged;
+		}
 
-        private void OnContentChanged(object obj)
-        {
-            if (AnimateOnChange)
-            {
-                PseudoClasses.Remove(":normal");
-                PseudoClasses.Add(":normal");
-            }
-        }
+		private void OnContentChanged(object? sender, SelectionChangedEventArgs e)
+		{
+			if (AnimateOnChange)
+			{
+				PseudoClasses.Remove(":normal");
+				PseudoClasses.Add(":normal");
+			}
+		}
 
-        public bool AnimateOnChange
-        {
-            get => GetValue(AnimateOnChangeProperty);
-            set => SetValue(AnimateOnChangeProperty, value);
-        }
+		public bool AnimateOnChange
+		{
+			get => GetValue(AnimateOnChangeProperty);
+			set => SetValue(AnimateOnChangeProperty, value);
+		}
 
-        public static readonly StyledProperty<bool> AnimateOnChangeProperty =
-            AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(AnimateOnChange), true);
-    }
+		public static readonly StyledProperty<bool> AnimateOnChangeProperty =
+			AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(AnimateOnChange), true);
+	}
 }

--- a/AnimationOnTabControlChange/AnimationOnTabControlChange.csproj
+++ b/AnimationOnTabControlChange/AnimationOnTabControlChange.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
+    <PackageReference Include="Avalonia" Version="11.2.7" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.7" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.10" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.7" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
    </ItemGroup>
 </Project>

--- a/AnimationOnTabControlChange/App.axaml
+++ b/AnimationOnTabControlChange/App.axaml
@@ -1,7 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="AnimationOnTabControlChange.App">
-    <Application.Styles>
-        <FluentTheme Mode="Light"/>
-    </Application.Styles>
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 x:Class="AnimationOnTabControlChange.App"
+			 RequestedThemeVariant="Light">
+	<Application.Styles>
+		<FluentTheme />
+	</Application.Styles>
 </Application>


### PR DESCRIPTION
Hola,

To keep this beautiful animation code up to date, I propose some framework updates (.net 8.0 & Avalonia 11.2.7) and related code updates.

Framework updates:
* TargetFramework to net8.0 from net5.0
* Avalonia to 11.2.7 from 0.10.10

Code updates:
* Theme handling at App.axaml and project package reference to Avalonia.Themes.Fluent (ref [1])
* Subcribe to SelectionChanged event instead of SelectedContentProperty observable (ref [2])
* The IStyleable interface is deprecated, code updated as recommended (ref [3])
* Removed unnecessary usings

[1]: https://docs.avaloniaui.net/docs/stay-up-to-date/upgrade-from-0.10#theme-handling
[2]: https://docs.avaloniaui.net/docs/stay-up-to-date/upgrade-from-0.10#systemreactiveobservables
[3]: https://docs.avaloniaui.net/docs/stay-up-to-date/upgrade-from-0.10#optional-but-recommended
