### PR TITLE
Animation Improvements

### DIFF
--- a/AnimationOnTabControlChange/AnimateTabControl.cs
+++ b/AnimationOnTabControlChange/AnimateTabControl.cs
@@ -5,10 +5,11 @@ using System;
 
 namespace AnimationOnTabControlChange
 {
-	[PseudoClasses(":normal")]
+	[PseudoClasses(":normal", ":reverse")]
 	public class AnimateTabControl : TabControl
 	{
 		protected override Type StyleKeyOverride => typeof(TabControl);
+		private int _lastSelectedIndex;
 
 		public AnimateTabControl()
 		{
@@ -23,11 +24,24 @@ namespace AnimationOnTabControlChange
 
 		private void OnContentChanged(object? sender, SelectionChangedEventArgs e)
 		{
-			if (AnimateOnChange)
+			if (!AnimateOnChange) return;
+			
+			PseudoClasses.Remove(":normal");
+			PseudoClasses.Remove(":reverse");
+			switch (AnimationType)
 			{
-				PseudoClasses.Remove(":normal");
-				PseudoClasses.Add(":normal");
+				case AnimationType.NORMAL_RTL:
+					PseudoClasses.Add(":normal");
+					break;
+				case AnimationType.REVERSE_LTR:
+					PseudoClasses.Add(":reverse");
+					break;
+				case AnimationType.DEFAULT:
+				default:
+					PseudoClasses.Add(_lastSelectedIndex <= SelectedIndex ? ":normal" : ":reverse");
+					break;
 			}
+			_lastSelectedIndex = SelectedIndex;
 		}
 
 		public bool AnimateOnChange
@@ -39,9 +53,11 @@ namespace AnimationOnTabControlChange
 		public static readonly StyledProperty<bool> AnimateOnChangeProperty =
 			AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(AnimateOnChange), true);
 
+		#region SKIP INITIAL
+		
 		/// <summary>
-		/// Identifies the SkipInitialAnimation property, which determines whether
-		/// the initial animation is skipped when the control is first displayed or attached to the visual tree.
+		/// Determines whether the initial animation is skipped when the control is first displayed or
+		/// attached to the visual tree.
 		/// </summary>
 		public static readonly StyledProperty<bool> SkipInitialAnimationProperty =
 			AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(SkipInitialAnimation), true);
@@ -55,5 +71,26 @@ namespace AnimationOnTabControlChange
 			get => GetValue(SkipInitialAnimationProperty);
 			set => SetValue(SkipInitialAnimationProperty, value);
 		}
+		
+		#endregion
+
+		#region TYPE
+
+		/// <summary>
+		/// Defines the type of animation used when transitioning between tabs in the AnimateTabControl.
+		/// </summary>
+		public static readonly StyledProperty<AnimationType> AnimationTypeProperty =
+			AvaloniaProperty.Register<AnimateTabControl, AnimationType>(nameof(AnimationType), AnimationType.DEFAULT);
+
+		/// <summary>
+		/// Gets or sets the AnimationType property, which defines the type of animation
+		/// used when transitioning between tabs in the AnimateTabControl.
+		/// </summary>
+		public AnimationType AnimationType
+		{
+			get => GetValue(AnimationTypeProperty);
+			set => SetValue(AnimationTypeProperty, value);
+		}
+		#endregion
 	}
 }

--- a/AnimationOnTabControlChange/AnimateTabControl.cs
+++ b/AnimationOnTabControlChange/AnimateTabControl.cs
@@ -12,8 +12,13 @@ namespace AnimationOnTabControlChange
 
 		public AnimateTabControl()
 		{
-			PseudoClasses.Add(":normal");
-			SelectionChanged += OnContentChanged;
+			if (!SkipInitialAnimation)
+				AttachedToVisualTree += (_, _) => SelectionChanged += OnContentChanged;
+			else
+			{
+				PseudoClasses.Add(":normal");
+				SelectionChanged += OnContentChanged;
+			}
 		}
 
 		private void OnContentChanged(object? sender, SelectionChangedEventArgs e)
@@ -33,5 +38,22 @@ namespace AnimationOnTabControlChange
 
 		public static readonly StyledProperty<bool> AnimateOnChangeProperty =
 			AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(AnimateOnChange), true);
+
+		/// <summary>
+		/// Identifies the SkipInitialAnimation property, which determines whether
+		/// the initial animation is skipped when the control is first displayed or attached to the visual tree.
+		/// </summary>
+		public static readonly StyledProperty<bool> SkipInitialAnimationProperty =
+			AvaloniaProperty.Register<AnimateTabControl, bool>(nameof(SkipInitialAnimation), true);
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the initial animation should be skipped
+		/// when the control is first displayed or attached to the visual tree.
+		/// </summary>
+		public bool SkipInitialAnimation
+		{
+			get => GetValue(SkipInitialAnimationProperty);
+			set => SetValue(SkipInitialAnimationProperty, value);
+		}
 	}
 }

--- a/AnimationOnTabControlChange/AnimationType.cs
+++ b/AnimationOnTabControlChange/AnimationType.cs
@@ -1,0 +1,17 @@
+namespace AnimationOnTabControlChange;
+
+public enum AnimationType
+{
+    /// <summary>
+    /// Animates the tab control based on the selected index.
+    /// </summary>
+    DEFAULT = 0,
+    /// <summary>
+    /// All animations will be "right-to-left" 
+    /// </summary>
+    NORMAL_RTL = 1,
+    /// <summary>
+    /// All animations will be "left-to-right"
+    /// </summary>
+    REVERSE_LTR = 2
+}

--- a/AnimationOnTabControlChange/MainWindow.axaml
+++ b/AnimationOnTabControlChange/MainWindow.axaml
@@ -22,7 +22,7 @@
     </Style>
   </Window.Styles>
   
-  <AnimateTabControl>
+  <AnimateTabControl SkipInitialAnimation="False">
     <TabItem Header="Header 1" Content="Content 1"/>
     <TabItem Header="Header 2" Content="Content 2"/>
     <TabItem Header="Header 3" Content="Content 3"/>

--- a/AnimationOnTabControlChange/MainWindow.axaml
+++ b/AnimationOnTabControlChange/MainWindow.axaml
@@ -20,9 +20,23 @@
         </Animation>
       </Style.Animations>
     </Style>
+    <Style Selector="TabControl:reverse /template/ ContentPresenter">
+      <Style.Animations>
+        <Animation Duration="0:0:0.5" FillMode="Backward" Easing="CubicEaseOut">
+          <KeyFrame Cue="0%">
+            <Setter Property="TranslateTransform.X" Value="-100" />
+            <Setter Property="Opacity" Value="0" />
+          </KeyFrame>
+          <KeyFrame Cue="100%">
+            <Setter Property="TranslateTransform.X" Value="0" />
+            <Setter Property="Opacity" Value="1" />
+          </KeyFrame>
+        </Animation>
+      </Style.Animations>
+    </Style>
   </Window.Styles>
   
-  <AnimateTabControl SkipInitialAnimation="False">
+  <AnimateTabControl SkipInitialAnimation="True" AnimationType="DEFAULT">
     <TabItem Header="Header 1" Content="Content 1"/>
     <TabItem Header="Header 2" Content="Content 2"/>
     <TabItem Header="Header 3" Content="Content 3"/>


### PR DESCRIPTION
Hey,

This repository helped me understanding classes, styles and animations in Avalonia, so I thought I'd contribute back what I improved :).

### SkipInitialAnimation

In the original version, the initial tab was animated, when the TabControl was attached / rendered. This looked weird when using inside a dialog / modal. So I introduced a property `SkipInitialAnimation` that, if set to true, will only attach to events after the TabControl has been attached, so "Content 1" will not be animated.

It defaults to *true*.

### AnimationType

I found it weird that everything was animated RTL, even though Header1 is to the left of Header2. So I added the `:reverse` class that animates from LTR.
I introduced the property `AnimationType` with an enumeration that does the following:

- Default: Based on the index of the previous selected tab the new tab will _either_ animate from RTL `normal` (when `SelectedIndex > _lastSelectedIndex`) OR animate from LTR `reverse` (when `SelectedIndex <= _lastSelectedIndex`)
- Normal: *All* animations will be done as previous RTL
- Reverse: *All* animations will be done with new `:reverse` LTR